### PR TITLE
Update python-build.yml

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Build package
       run: python -m build
     - name: Upload artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: wheels
         path: dist/*.whl


### PR DESCRIPTION
Upload artifacts v1 and v2 are deprecated. Updated to V4