### PR TITLE
Update mymc.py

### DIFF
--- a/mymcplusplus/mymc.py
+++ b/mymcplusplus/mymc.py
@@ -251,7 +251,7 @@ def do_export(cmd, mc, opts, args, opterr):
         if opts.longnames:
             filename = (ps2save.make_longname(dirname, sf) + "." + opts.type)
         if filename == None:
-            filename = dirname + "." + opts.type
+            filename = (ps2save.make_longname(dirname, sf) + "." + opts.type)
                 
         if not opts.overwrite_existing:
             exists = True
@@ -266,7 +266,7 @@ def do_export(cmd, mc, opts, args, opterr):
             
         f = open(filename, "wb")
         try:
-            print("Exporing", dirname, "to", filename)
+            print("Exporting", dirname, "to", filename)
             
             if opts.type == "max":
                 format_max_drive.save(sf, f)


### PR DESCRIPTION
Sometimes saves contains characters in its filename that is not allowed as filenames in the file system.  When exporting the save via command line, mymcplusplus throws an error because it's unable to save to disk with the "invalid" characters. Some games could possibly contain the following characters in their save file name:

```
< (less than)
> (greater than)
: (colon)
" (double quote)
/ (forward slash)
\ (backslash)
| (vertical bar or pipe)
? (question mark)
* (asterisk)
```

For example:
Outlaw Golf 2 memory card directory structure:
```
BASLUS-21030O>t+r\ic             Outlaw Golf 2
  38KB Not Protected

BASLUS-21030                     Outlaw
  36KB Not Protected              Golf 2 Options
```

The command I used to extract all saves from the memory card:
`mymcplusplus -i SLUS-21030-1.mc2 export *`

Error from mymcplusplus when attempting to extract `BASLUS-21030O>t+r\ic`
```
mymcplusplus -i SLUS-21030-1.mc2 export BASLUS-21030O>t+r\ic
BASLUS-21030O>t+r\ic.psu: Invalid argument
```

I can successfully extract the other save
```
mymcplusplus -i SLUS-21030-1.mc2 export BASLUS-21030
Exporing BASLUS-21030 to BASLUS-21030.psu
```

When exporting the save via the gui, it auto-populates the "BASLUS-21030O>t+r\ic " save with "SLUS-21030 Outlaw Golf 2 (7FF2A0DA).psu". 
 
This fixes an issue when exporting a save with invalid characters in the filename using the command line. 
